### PR TITLE
feat: Wrench Jr — bot Discord avec commande /flag OSINT

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -1,0 +1,1 @@
+DISCORD_TOKEN=ton_token_ici

--- a/bot/.gitignore
+++ b/bot/.gitignore
@@ -1,0 +1,3 @@
+.env
+__pycache__/
+*.pyc

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -5,16 +5,25 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
+if not DISCORD_TOKEN:
+    raise RuntimeError("DISCORD_TOKEN manquant. Copie .env.example vers .env et renseigne le token.")
+
 AVATAR_URL = "https://raw.githubusercontent.com/Th3rdMan/Wrench-Userscript/main/wrench.png"
 
 intents = discord.Intents.default()
 client = discord.Client(intents=intents)
 tree = app_commands.CommandTree(client)
 
+_synced = False
+
 
 @client.event
 async def on_ready():
-    await tree.sync()
+    global _synced
+    if not _synced:
+        await tree.sync()
+        _synced = True
     print(f"Wrench Jr connecté en tant que {client.user}")
 
 
@@ -33,15 +42,17 @@ async def flag(
     color = discord.Color.green() if valide else discord.Color.red()
     status_text = "✅ Validé" if valide else "❌ Non validé"
 
+    escaped_reponse = discord.utils.escape_markdown(reponse)
+
     embed = discord.Embed(
         title=f"🚩 {nom}",
         color=color,
     )
-    embed.add_field(name="Réponse soumise", value=f"`{reponse}`", inline=False)
+    embed.add_field(name="Réponse soumise", value=f"`{escaped_reponse}`", inline=False)
     embed.add_field(name="Statut", value=status_text, inline=False)
     embed.set_footer(text="Wrench Jr • OSINT Flag Tracker", icon_url=AVATAR_URL)
 
     await interaction.response.send_message(embed=embed)
 
 
-client.run(os.environ["DISCORD_TOKEN"])
+client.run(DISCORD_TOKEN)

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,0 +1,47 @@
+import os
+import discord
+from discord import app_commands
+from dotenv import load_dotenv
+
+load_dotenv()
+
+AVATAR_URL = "https://raw.githubusercontent.com/Th3rdMan/Wrench-Userscript/main/wrench.png"
+
+intents = discord.Intents.default()
+client = discord.Client(intents=intents)
+tree = app_commands.CommandTree(client)
+
+
+@client.event
+async def on_ready():
+    await tree.sync()
+    print(f"Wrench Jr connecté en tant que {client.user}")
+
+
+@tree.command(name="flag", description="Soumettre un flag OSINT avec sa réponse")
+@app_commands.describe(
+    nom="Nom du flag OSINT",
+    reponse="Réponse soumise pour ce flag",
+    valide="Le flag est-il validé ?",
+)
+async def flag(
+    interaction: discord.Interaction,
+    nom: str,
+    reponse: str,
+    valide: bool,
+):
+    color = discord.Color.green() if valide else discord.Color.red()
+    status_text = "✅ Validé" if valide else "❌ Non validé"
+
+    embed = discord.Embed(
+        title=f"🚩 {nom}",
+        color=color,
+    )
+    embed.add_field(name="Réponse soumise", value=f"`{reponse}`", inline=False)
+    embed.add_field(name="Statut", value=status_text, inline=False)
+    embed.set_footer(text="Wrench Jr • OSINT Flag Tracker", icon_url=AVATAR_URL)
+
+    await interaction.response.send_message(embed=embed)
+
+
+client.run(os.environ["DISCORD_TOKEN"])

--- a/bot/requirements.txt
+++ b/bot/requirements.txt
@@ -1,0 +1,2 @@
+discord.py>=2.3.0
+python-dotenv>=1.0.0


### PR DESCRIPTION
## Résumé

- Ajout du bot Discord **Wrench Jr** dans `bot/`
- Commande slash `/flag` avec trois paramètres : `nom`, `reponse`, `valide`
- Réponse sous forme d'embed Discord coloré (vert = validé ✅, rouge = non validé ❌)
- Footer avec l'avatar Wrench et le texte "Wrench Jr • OSINT Flag Tracker"

## Utilisation

```bash
cd bot
pip install -r requirements.txt
cp .env.example .env   # renseigner DISCORD_TOKEN
python bot.py
```

## Test plan

- [ ] Inviter le bot sur un serveur Discord (portée : `bot` + `applications.commands`)
- [ ] Taper `/flag nom:"Géolocalisation #1" reponse:"Paris" valide:True` → embed vert
- [ ] Taper `/flag nom:"Géolocalisation #1" reponse:"Lyon" valide:False` → embed rouge
- [ ] Vérifier que le footer affiche bien l'avatar Wrench

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hk3qCV77t2dSKYHzUh9dbW)_

## Summary by Sourcery

Introduce a Discord-based OSINT flag tracking bot with a slash command interface.

New Features:
- Add Wrench Jr Discord bot application under the bot/ directory.
- Expose a /flag slash command to submit OSINT flags with name, answer, and validation status.
- Display submitted flags as color-coded Discord embeds with OSINT-specific footer branding.

Build:
- Add Python dependencies for discord.py and python-dotenv for the new bot.